### PR TITLE
Create setup-node@v1.4.2   with:     # Set always-auth in npmrc     a…

### DIFF
--- a/.github/workflows/blank.yml- name: Setup Node.js environment   uses: actions/setup-node@v1.4.2   with:     # Set always-auth in npmrc     always-auth: # optional, default is false     # Version Spec of the version to use.  Examples: 10.x, 10.15.1, >=10.15.0     node-version: # optional, default is 10.x     # Optional registry to set up for auth. Will set the registry in a project level .npmrc and .yarnrc file, and set up auth to read in from env.NODE_AUTH_TOKEN     registry-url: # optional     # Optional scope for authenticating against scoped registries     scope: # optional     # Deprecated. Use node-version instead. Will not be supported after October 1, 2019     version: # optional
+++ b/.github/workflows/blank.yml- name: Setup Node.js environment   uses: actions/setup-node@v1.4.2   with:     # Set always-auth in npmrc     always-auth: # optional, default is false     # Version Spec of the version to use.  Examples: 10.x, 10.15.1, >=10.15.0     node-version: # optional, default is 10.x     # Optional registry to set up for auth. Will set the registry in a project level .npmrc and .yarnrc file, and set up auth to read in from env.NODE_AUTH_TOKEN     registry-url: # optional     # Optional scope for authenticating against scoped registries     scope: # optional     # Deprecated. Use node-version instead. Will not be supported after October 1, 2019     version: # optional
@@ -1,0 +1,33 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+
+    # Runs a single command using the runners shell
+    - name: Run a one-line script
+      run: echo Hello, world!
+
+    # Runs a set of commands using the runners shell
+    - name: Run a multi-line script
+      run: |
+        echo Add other actions to build,
+        echo test, and deploy your project.


### PR DESCRIPTION
…lways-auth: # optional, default is false     # Version Spec of the version to use.  Examples: 10.x, 10.15.1, >=10.15.0     node-version: # optional, default is 10.x     # Optional registry to set up for auth. Will set the registry in a project level .npmrc and .yarnrc file, and set up auth to read in from env.NODE_AUTH_TOKEN     registry-url: # optional     # Optional scope for authenticating against scoped registries     scope: # optional     # Deprecated. Use node-version instead. Will not be supported after October 1, 2019     version: # optional